### PR TITLE
Use Self Hosted Runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Run tests on my own machine so I don't have to wait to acquire GHA server